### PR TITLE
Close DBF and AfterBuild package

### DIFF
--- a/packages/DynamoGIS/pkg.json
+++ b/packages/DynamoGIS/pkg.json
@@ -1,0 +1,18 @@
+{
+	"license":"",
+	"file_hash":null,
+	"name":"DynamoGIS",
+	"version":"0.2.2",
+	"description":"Shape file reader for Dyanmo",
+	"group":"GIS",
+	"keywords":["gis","shapefile"],
+	"dependencies":[],
+	"contents":"",
+	"engine_version":"0.8.3.2491",
+	"engine":"dynamo",
+	"engine_metadata":"",
+	"site_url":"",
+	"repository_url":"",
+	"contains_binaries":true,
+	"node_libraries":["EGIS.DynamoLib, Version=0.2.0.0, Culture=neutral, PublicKeyToken=null"]
+}

--- a/src/EGIS.DynamoLib/EGIS.DynamoLib.csproj
+++ b/src/EGIS.DynamoLib/EGIS.DynamoLib.csproj
@@ -66,7 +66,19 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <Dlls Include="$(OutDir)*.dll" />
+      <Pdbs Include="$(OutDir)*.pdb" />
+      <Xmls Include="$(OutDir)*.xml" />
+      <Configs Include="$(OutDir)*.config" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Dlls)" DestinationFolder="$(SolutionDir)..\packages\DynamoGIS\bin\" />
+    <Copy SourceFiles="@(Pdbs)" DestinationFolder="$(SolutionDir)..\packages\DynamoGIS\bin\" />
+    <Copy SourceFiles="@(Xmls)" DestinationFolder="$(SolutionDir)..\packages\DynamoGIS\bin\" />
+    <Copy SourceFiles="@(Configs)" DestinationFolder="$(SolutionDir)..\packages\DynamoGIS\bin\" />
+    <MakeDir Directories="$(SolutionDir)..\packages\DynamoGIS\dyf" />
+    <MakeDir Directories="$(SolutionDir)..\packages\DynamoGIS\extra" />
+  </Target>
 </Project>

--- a/src/EGIS.DynamoLib/ShapeFileReader.cs
+++ b/src/EGIS.DynamoLib/ShapeFileReader.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Autodesk.DesignScript.Geometry;
 using EGIS.ShapeFileLib;
 using System.IO;
+using System;
 
 namespace EGIS.DynamoLib
 {
@@ -16,7 +17,7 @@ namespace EGIS.DynamoLib
     /// <summary>
     /// Represents the shape read from ShapeFile
     /// </summary>
-    public class Shape
+    public class Shape : IDisposable
     {
         /// <summary>
         /// Represents raw shape data
@@ -46,6 +47,17 @@ namespace EGIS.DynamoLib
             }
             string dbfFilePath = Path.ChangeExtension(shapeFilePath, "dbf");
             Database = new DbfReader(dbfFilePath);
+        }
+
+        /// <summary>
+        /// Closes the Database at the end of the execution
+        /// </summary>
+        public void Dispose()
+        {
+            if (Database != null)
+            {
+                Database.Close();
+            }
         }
 
         /// <summary>
@@ -81,7 +93,7 @@ namespace EGIS.DynamoLib
                 {
                     item.Dispose();
                 }
-                
+
                 return polygon;
             });
         }


### PR DESCRIPTION
This PR resolves #2 and also creates the package with an AfterBuild Target.
now the DBF file is released by exiting Dynamo (no need to quit Revit).
